### PR TITLE
make bash_aliases.j2 compatible to python3

### DIFF
--- a/templates/etc/skel/.bash_aliases.j2
+++ b/templates/etc/skel/.bash_aliases.j2
@@ -13,6 +13,6 @@ if [ -x /usr/bin/dircolors ]; then
   alias egrep='egrep --color=auto'
 fi
 
-{% for key, value in bash_aliases.iteritems() %}
+{% for key, value in bash_aliases.items() %}
 alias {{ key }}='{{ value }}'
 {% endfor %}


### PR DESCRIPTION
iteritems() is not available in python3 anymore. But items() is in both versions (python2 and python3).